### PR TITLE
Task bugfixes

### DIFF
--- a/src/ChatManager.cpp
+++ b/src/ChatManager.cpp
@@ -684,7 +684,7 @@ void lairUnlockCommand(std::string full, std::vector<std::string>& args, CNSocke
     }
 
     INITSTRUCT(sP_FE2CL_REP_PC_TASK_START_SUCC, taskResp);
-    MissionManager::startTask(plr, taskID, false);
+    MissionManager::startTask(plr, taskID);
     taskResp.iTaskNum = taskID;
     taskResp.iRemainTime = 0;
     sock->sendPacket((void*)&taskResp, P_FE2CL_REP_PC_TASK_START_SUCC, sizeof(sP_FE2CL_REP_PC_TASK_START_SUCC));

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1,5 +1,4 @@
 #include "Database.hpp"
-#include "Database.hpp"
 #include "CNProtocol.hpp"
 #include "CNStructs.hpp"
 #include "settings.hpp"
@@ -995,13 +994,18 @@ void Database::getPlayer(Player* plr, int id) {
     sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
     sqlite3_bind_int(stmt, 1, id);
 
-    int i = 0;
-    while (sqlite3_step(stmt) == SQLITE_ROW && i < ACTIVE_MISSION_COUNT) {
-        plr->tasks[i] = sqlite3_column_int(stmt, 0);
+    std::set<int> tasksSet; // used to prevent duplicate tasks from loading in
+    for (int i = 0; sqlite3_step(stmt) == SQLITE_ROW && i < ACTIVE_MISSION_COUNT; i++) {
+
+        int taskID = sqlite3_column_int(stmt, 0);
+        if (tasksSet.find(taskID) != tasksSet.end())
+            continue;
+
+        plr->tasks[i] = taskID;
+        tasksSet.insert(taskID);
         plr->RemainingNPCCount[i][0] = sqlite3_column_int(stmt, 1);
         plr->RemainingNPCCount[i][1] = sqlite3_column_int(stmt, 2);
         plr->RemainingNPCCount[i][2] = sqlite3_column_int(stmt, 3);
-        i++;
     }
 
     sqlite3_finalize(stmt);
@@ -1017,7 +1021,7 @@ void Database::getPlayer(Player* plr, int id) {
     sqlite3_bind_int(stmt, 1, id);
     sqlite3_bind_int(stmt, 2, id);
 
-    i = 0;
+    int i = 0;
     while (sqlite3_step(stmt) == SQLITE_ROW && i < 50) {
         int PlayerAId = sqlite3_column_int(stmt, 0);
         int PlayerBId = sqlite3_column_int(stmt, 1);

--- a/src/MissionManager.cpp
+++ b/src/MissionManager.cpp
@@ -601,7 +601,7 @@ void MissionManager::failInstancedMissions(CNSocket* sock) {
             int failTaskID = task->task["m_iFOutgoingTask"];
             if (failTaskID != 0) {
                 MissionManager::quitTask(sock, taskNum, false);
-                plr->tasks[i] = failTaskID;
+                //plr->tasks[i] = failTaskID; // this causes the client to freak out and send a dupe task
             }
         }
     }

--- a/src/MissionManager.hpp
+++ b/src/MissionManager.hpp
@@ -41,7 +41,7 @@ namespace MissionManager {
     extern nlohmann::json AvatarGrowth[37];
     void init();
 
-    bool startTask(Player* plr, int TaskID, bool NanoMission);
+    bool startTask(Player* plr, int TaskID);
     void taskStart(CNSocket* sock, CNPacketData* data);
     void taskEnd(CNSocket* sock, CNPacketData* data);
     void setMission(CNSocket* sock, CNPacketData* data);


### PR DESCRIPTION
- Use the XDT to determine if a mission is a nano mission (fixes disappearing nano missions)
- Don't set fallback task ID serverside on instance exit (fixes serverside duplicate tasks)
- Add checks to ensure duplicate tasks are not started by the client or loaded from the database